### PR TITLE
handle SimpleSAML access via nginx

### DIFF
--- a/config/ts-dev.conf
+++ b/config/ts-dev.conf
@@ -33,6 +33,19 @@ error_log "/usr/local/var/log/nginx/server.localhost.error.log";
 
 root $basepath/$rootpath;
 
+
+# handle simplesaml
+location ~ /simplesaml {
+    index index.php;
+    location ~ ^(?<prefix>/simplesaml)(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
+        include fastcgi.conf;
+        fastcgi_param SERVER_NAME $servername;
+        fastcgi_split_path_info ^(.+?\.php)(/.+)$;
+        fastcgi_param PATH_INFO $pathinfo if_not_empty;
+        fastcgi_pass php;
+   }
+}
+
 location / {
   try_files $uri $uri/ /index.php?$args;
 }


### PR DESCRIPTION
SimpleSAML setup via nginx. I'm confident this won't impact any other localhost config, but please let me know if there are concerns.