### PR TITLE
Install cgr scripts under oldest php version for backwards compat

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -8,7 +8,9 @@ if brew list php; then
   echo $'\n'
   echo "Installing PECL extensions (xdebug) for each version of PHP"
   echo $'\n'
+
   brew unlink php
+
   for VER in 5.6 7.0 7.1 7.2
   do
     brew link --force php@$VER
@@ -21,22 +23,28 @@ if brew list php; then
     brew unlink php@$VER
   done
 
-  brew link php
-
   echo $'\n'
   echo "Installing TS config for each version of PHP"
   echo $'\n'
+
   for VER in 5.6 7.0 7.1 7.2
   do
     $(brew --prefix gettext)/bin/envsubst < config/php-ts.ini > $(brew --prefix)/etc/php/$VER/conf.d/php-ts.ini
   done
 
-  echo $'\n'
-  echo "Starting PHP7 FPM process."
-  echo $'\n'
-  brew services start php
+  # Install cgr scripts under oldest php version for backwards compat
+  brew link --force php@5.6
 
   source scripts/cgr.sh
+
+  brew unlink php@5.6
+
+  echo $'\n'
+  echo "Starting PHP."
+  echo $'\n'
+
+  brew link php
+  brew services start php
 
   cp -n config/drushrc.php ~/.drush
 fi


### PR DESCRIPTION
Noticed `terminus` wasn't working when I was running php 5.6, because the cgr package was installed with php 7.2. This PR should make the packages work for older php versions.

Workaround for an existing environment: 
```sh
sphp 5.6
cgr update pantheon-systems/terminus
```