### PR TITLE
Auto-detect projects that use a nested web directory

### DIFF
--- a/config/ts-dev.conf
+++ b/config/ts-dev.conf
@@ -18,6 +18,11 @@ if ($domain ~ "^(.[^.]*)\.localhost$") {
 	set $servername "${domain}.localhost";
 }
 
+# auto-mapping to the "web" directory
+if (-d $basepath/$rootpath/web) {
+	set $rootpath "${rootpath}/web";
+}
+
 # check multi name domain to multi application
 if ($domain ~ "^(.*)\.(.[^.]*)\.localhost$") {
 	set $subdomain $1;


### PR DESCRIPTION
This pull request works around a problem I noticed where, for most D8 projects, I have to use the "web.sitename.localhost" domain instead of just using "sitename.localhost".

I updated the NGINX configuration to detect the web directory and automatically change the root if it exists. If a multi name domain is passed, that still works due to the order in which the if statements are executed.