### PR TITLE
Error during usage suggested this change

### DIFF
--- a/Brewfile-dev
+++ b/Brewfile-dev
@@ -1,6 +1,6 @@
 cask_args appdir: '/Applications'
 
-tap 'caskroom/versions'
+tap 'homebrew/cask-versions'
 tap 'homebrew/services'
 
 brew 'colordiff'


### PR DESCRIPTION
"Error: caskroom/versions was moved. Tap homebrew/cask-versions instead."