### PR TITLE
Use latest stable rbenv

### DIFF
--- a/environment_setup.sh
+++ b/environment_setup.sh
@@ -104,8 +104,8 @@ if confirmupdate "Would you like to install local development programs like PHPS
      echo $'Failed to install Rbenv. Please rbenv init for your shell. Sorry.'
      echo $'\n'
   fi
-  rbenv install 2.2.2
-  rbenv global 2.2.2
+  rbenv install 2.6.5
+  rbenv global 2.6.5
 
   installed=`which bundler`
   if [ "$installed" == "" ] ; then


### PR DESCRIPTION
Running the environment setup script, it's yelling at me about an old version of rbenv. Looks to me like the latest stable is 2.6.5: does this change look ok?