### PR TITLE
Increase PHP memory limit

### DIFF
--- a/config/php-ts.ini
+++ b/config/php-ts.ini
@@ -1,5 +1,5 @@
 date.timezone = "America/Los_Angeles"
-memory_limit = 512M
+memory_limit = 4GB
 post_max_size = 200M
 upload_max_filesize = 100M
 default_socket_timeout = 600

--- a/config/php-ts.ini
+++ b/config/php-ts.ini
@@ -1,5 +1,5 @@
 date.timezone = "America/Los_Angeles"
-memory_limit = 4GB
+memory_limit = -1
 post_max_size = 200M
 upload_max_filesize = 100M
 default_socket_timeout = 600

--- a/config/ts-dev.conf
+++ b/config/ts-dev.conf
@@ -55,6 +55,7 @@ location ~ \.php$ {
   include fastcgi.conf;
 
   fastcgi_param SERVER_NAME $servername;
+  fastcgi_param PHP_VALUE "memory_limit = 512M";
 
   fastcgi_intercept_errors on;
   fastcgi_buffers 8 16k;


### PR DESCRIPTION
We're running all sorts of composer and terminus operations that require disabling memory limits manually. Can we just increase? This was a delight for me locally.