### PR TITLE
Update to Xdebug config for version 3

### DIFF
--- a/config/php-ts.ini
+++ b/config/php-ts.ini
@@ -19,5 +19,13 @@ xdebug.client_host=localhost
 xdebug.start_with_request=yes
 xdebug.mode=debug
 
+; Xdebug 2 configuration, not required for ^3.0
+xdebug.default_enable=1
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.remote_host=localhost
+xdebug.remote_port=9001
+xdebug.remote_autostart=1
+
 ; Needed for Drupal 8
 xdebug.max_nesting_level = 256

--- a/config/php-ts.ini
+++ b/config/php-ts.ini
@@ -14,11 +14,10 @@ cgi.fix_pathinfo = 0
 error_log = /usr/local/var/log/php-error.log
 
 [xdebug]
-xdebug.default_enable=1
-xdebug.remote_enable=1
-xdebug.remote_handler=dbgp
-xdebug.remote_host=localhost
-xdebug.remote_port=9001
-xdebug.remote_autostart=1
+xdebug.client_port=9001
+xdebug.client_host=localhost
+xdebug.start_with_request=yes
+xdebug.mode=debug
+
 ; Needed for Drupal 8
 xdebug.max_nesting_level = 256


### PR DESCRIPTION
Version 3 of Xdebug has some configuration differences, documented here:
https://xdebug.org/docs/upgrade_guide#changed-%22xdebug.remote_port%22

This is my first day using Xdebug, so I might be missing some important elements, but this is working for me at the moment.
