### PR TITLE
Updating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ TS Environment
 
 Sets you up with a server environment on a Mac for Drupal development. If you need examples of how to install common packages with Homebrew, checkout environment_setup.sh
 
-### Requirements:
-
- - Xcode command line tools: `xcode-select --install`
-
+### Getting Started:
 ```
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/thinkshout/ts_environment/master/environment_setup.sh)"
+cd ~
+xcode-select --install
+git clone git@github.com:thinkshout/ts_environment.git
+cd ts_environment
+./environment_setup.sh
 ```
 
 Once installed you can upgrade your packages to the current stable versions like so:


### PR DESCRIPTION
Per a Slack conversation with @wxactly, updating instructions to clarify how to get started and replacing the assumption that a one-liner is needed ito kick off environment_setup.sh, with a clearer multi-line process.