### PR TITLE
Update to config to fix file uploads, new ssl syntax

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -39,9 +39,8 @@ http {
   }
 
   server {
-    listen       8443;
+    listen       8443 ssl;
 
-    ssl                  on;
     ssl_certificate      ssl/dev.crt;
     ssl_certificate_key  ssl/dev.key;
 
@@ -55,5 +54,3 @@ http {
   }
 
 }
-
-

--- a/config/ts-dev.conf
+++ b/config/ts-dev.conf
@@ -4,6 +4,7 @@ set $basepath "${USERHOME}/Sites";
 set $domain $host;
 
 client_max_body_size 100M;
+client_body_buffer_size 100M;
 
 # handle localhost
 if ($domain ~ "^localhost$") {


### PR DESCRIPTION
* The `client_body_buffer_size 100M;` fixed file uploads for me, which were broken locally (perhaps related to Monterey update?)
* The ssl change was something I found in the logs while trying to fix the file uploads - new syntax for ssl config