### PR TITLE
Increase nginx buffers

### DIFF
--- a/config/ts-dev.conf
+++ b/config/ts-dev.conf
@@ -58,8 +58,8 @@ location ~ \.php$ {
   fastcgi_param PHP_VALUE "memory_limit = 512M";
 
   fastcgi_intercept_errors on;
-  fastcgi_buffers 8 16k;
-  fastcgi_buffer_size 32k;
+  fastcgi_buffers 128 4096k;
+  fastcgi_buffer_size 4096k;
   fastcgi_connect_timeout 60;
   fastcgi_send_timeout 300;
   fastcgi_read_timeout 300;


### PR DESCRIPTION
When updating LVHN to D9, I was getting the below error on some pages. This change fixed it. Perhaps something we want to update in ts_environment.

==> /usr/local/var/log/nginx/server.localhost.error.log <==
2021/11/08 17:29:43 [error] 5897#0: *7695 upstream sent too big header while reading response header from upstream, client: 127.0.0.1, server: $servername, request: "GET /node/add/doctor HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "web.lvhn.localhost", referrer: "http://web.lvhn.localhost/user/1629"