### PR TITLE
Update php-ts.ini

### DIFF
--- a/config/php-ts.ini
+++ b/config/php-ts.ini
@@ -4,6 +4,7 @@ post_max_size = 200M
 upload_max_filesize = 100M
 default_socket_timeout = 600
 max_execution_time = 300
+max_input_vars = 10000
 
 opcache.enable=1
 opcache.memory_consumption=256


### PR DESCRIPTION
On LVHN, we ran into a problem where permissions would no longer save. The fix was to increase the max_input_vars value (default is 1000).
Perhaps worth changing for everyone. I couldn't see what value Pantheon has but I'm assuming it's more than the default.
Alternative to this change is to only edit a single role (/admin/people/permissions/reviewer vs /admin/people/permissions)