### PR TITLE
Update environment_setup.sh

### DIFF
--- a/environment_setup.sh
+++ b/environment_setup.sh
@@ -87,7 +87,8 @@ if confirmupdate "Would you like to install local development programs like PHPS
     
     is_m1=`which brew`
     if [ "$is_m1" == "/opt/homebrew/bin/brew" ] ; then
-      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+      (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
+      eval "$(/opt/homebrew/bin/brew shellenv)"
     fi
   fi
 


### PR DESCRIPTION
brew was not in the path yet. I updated the code based on the Homebrew installation instructions, the relevant part of which I have pasted here:

```
==> Next steps:

- Run these two commands in your terminal to add Homebrew to your PATH:

    (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/olivierbouwman/.zprofile

    eval "$(/opt/homebrew/bin/brew shellenv)"

```