### PR TITLE
Remove php7.3

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -11,7 +11,7 @@ if brew list php; then
 
   brew unlink php
 
-  for VER in 7.3 7.4 8.0 8.1
+  for VER in 7.4 8.0 8.1
   do
     brew link --force php@$VER
     php -v
@@ -23,18 +23,18 @@ if brew list php; then
   echo "Installing TS config for each version of PHP"
   echo $'\n'
 
-  for VER in 7.3 7.4 8.0 8.1
+  for VER in 7.4 8.0 8.1
   do
     $(brew --prefix gettext)/bin/envsubst < config/php-ts.ini > $(brew --prefix)/etc/php/$VER/conf.d/php-ts.ini
   done
 
   # Install cgr scripts under oldest php version for backwards compat
   brew unlink php
-  brew link --force php@7.3
+  brew link --force php@7.4
 
   source scripts/cgr.sh
 
-  brew unlink php@7.3
+  brew unlink php@7.4
 
   echo $'\n'
   echo "Starting PHP."


### PR DESCRIPTION
php7.3 was causing issues during install. According to this doc it's rare enough not to install by default anymore. https://docs.google.com/spreadsheets/u/1/d/1QrQ-Z8B5XqWjO1ct0voCc3PfG4PENSouu9nQzc8-AzU/edit#gid=0